### PR TITLE
Potential fix for code scanning alert no. 42: Clear-text logging of sensitive information

### DIFF
--- a/company/views_ajax.py
+++ b/company/views_ajax.py
@@ -661,7 +661,7 @@ def validate_auditor_reservation(request):
         target_date = data.get('date')
         appointment_id = data.get('appointment_id')  # ID trenutnog termina za izuzetak
         
-        logger.info(f"Primljeni podaci: auditor_id={auditor_id}, date={target_date}, appointment_id={appointment_id}")
+        logger.info("Primljeni podaci za proveru dostupnosti auditora su primljeni.")
         
         # Validacija podataka
         if not auditor_id or not target_date:


### PR DESCRIPTION
Potential fix for [https://github.com/Darkonyks/iasoqar-app/security/code-scanning/42](https://github.com/Darkonyks/iasoqar-app/security/code-scanning/42)

To fix this issue, we should avoid directly logging unfiltered or sensitive client-supplied data. The simplest solution is to change or remove the log line so that it does not emit the potentially sensitive values for `auditor_id`, `target_date`, or `appointment_id`. If logging is still desired for debugging purposes, we can either:  
- Remove the line entirely (preferred for privacy); or  
- Redact or mask the sensitive data (e.g., by replacing the actual values with '[REDACTED]' or logging only the presence of the fields and not their values).  
In this context, unless there is a strong need for these incoming values to be visible in logs, it's safest to remove the detailed data from the log statement.

**Change:**  
- Edit the log line at line 664 in `company/views_ajax.py`.  
- Either remove it, or change it to generically note that data was received (without showing the values).

No new imports or helper functions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
