### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/company/auditor_views.py
+++ b/company/auditor_views.py
@@ -519,7 +519,8 @@ def get_qualified_auditors(request):
         
         return JsonResponse({'success': True, 'data': qualified_auditors})
     except Exception as e:
-        return JsonResponse({'success': False, 'message': str(e)}, status=400)
+        logger.exception("Greška u get_qualified_auditors: %s", e)
+        return JsonResponse({'success': False, 'message': 'Desila se greška na serveru. Pokušajte ponovo.'}, status=400)
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/Darkonyks/iasoqar-app/security/code-scanning/2](https://github.com/Darkonyks/iasoqar-app/security/code-scanning/2)

The best way to fix this problem is to ensure that exception details are not exposed to the end user. Instead, we should:
- Catch the exception as before.
- Log the exception (including a stack trace) on the server using the application's logger, for developers/operators to review.
- Return a generic error message to the user. The generic message should not include any details about the codebase, logic, or system internals.
To implement these changes:
- In the exception handler (starting line 521), replace the line that returns `{'success': False, 'message': str(e)}` with one that logs the exception using the already-initialized logger (preferably `logger.exception(...)`), and returns `{'success': False, 'message': 'Desila se greška na serveru. Pokušajte ponovo.'}` (or a similar generic message) instead.
- No additional imports are needed, as `logger` is already defined using Python's `logging`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
